### PR TITLE
Explicitly configure unix socket

### DIFF
--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -43,7 +43,7 @@ defmodule Redix.PubSub.Connection do
   end
 
   def connect(info, state) do
-    case Utils.connect(state.opts) do
+    case establish_connection(state.opts) do
       {:ok, socket} ->
         state = %{state | socket: socket}
         if info == :backoff do
@@ -152,13 +152,20 @@ defmodule Redix.PubSub.Connection do
   ## Helper functions
 
   defp sync_connect(state) do
-    case Utils.connect(state.opts) do
+    case establish_connection(state.opts) do
       {:ok, socket} ->
         {:ok, %{state | socket: socket}}
       {:error, reason} ->
         {:stop, reason}
       {:stop, _reason} = stop ->
         stop
+    end
+  end
+
+  defp establish_connection(opts) do
+    with {:ok, socket} <- Utils.connect(opts),
+         :ok <- :inet.setopts(socket, active: :once) do
+      {:ok, socket}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule RedixPubsub.Mixfile do
 
   defp deps() do
     [{:connection, "~> 1.0"},
-     {:redix, "~> 0.5.0"},
+     {:redix, "~> 0.5.2"},
      {:earmark, ">= 0.0.0", only: :docs},
      {:ex_doc, ">= 0.0.0", only: :docs}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "redix": {:hex, :redix, "0.5.0", "46b81bdad24d4a330cd9f9eb26d6da6c40c8e5d1ce0c1607a82b4739f8f678c4", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}]}}
+  "redix": {:hex, :redix, "0.5.2", "82a7b3cf9141a8d3de7d38d321717fe7ae6f998561cd87d374ff9012db87913a", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}]}}


### PR DESCRIPTION
Resolves https://github.com/whatyouhide/redix/issues/64

Versions affected: `redis_pubsub 0.2.0` with `redix 0.5.2` and `0.6.0`.
Fix verified as working with `redix` versions: `0.5.0`, `0.5.1`, `0.5.2` and `0.6.0`.

Changes:

* Update `mix.exs` and `mix.lock` to bump tiny version of `redix` dependency, from `0.5.0` to `0.5.2`.
* Explicitly call [`:inet.setopts/2`](http://erlang.org/doc/man/inet.html#setopts-2) to configure the new socket.

Tested locally on macOS 10.12.3 with:
```
$ elixir -v
Erlang/OTP 19 [erts-8.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
Elixir 1.4.2
```



