### PR TITLE
Upgrade Redix dependency to 0.6.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule RedixPubsub.Mixfile do
 
   defp deps() do
     [{:connection, "~> 1.0"},
-     {:redix, "~> 0.5.2"},
+     {:redix, "~> 0.6.0"},
      {:ex_doc, "~> 0.15", only: :dev}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "redix": {:hex, :redix, "0.5.2", "82a7b3cf9141a8d3de7d38d321717fe7ae6f998561cd87d374ff9012db87913a", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}]}}
+  "redix": {:hex, :redix, "0.6.0", "b0ee9b66cd15b5fe72deeaba285e90b65dbf069b7be67f610d32d4304226b1b2", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}]}}


### PR DESCRIPTION
This PR is a followup to [this comment](https://github.com/whatyouhide/redix_pubsub/pull/8#issuecomment-293185940).

Changes:

* upgrade the required `redix` version in the Mixfile.
* update `Redix.PubSub.Connection` to work with the new `%Redix.ConnectionError{}` structs used by `redix 0.6.0`.

I've tested it in my package that heavily relies on both `redix` and `redix_pubsub`. My test suite [is green](https://travis-ci.org/tompave/fun_with_flags/builds/230571284) with [these changes](https://github.com/tompave/fun_with_flags/commit/419f30c9b28197ff52a4023e561bb58e9328ec2d).