### PR TITLE
Fix error in handling connection errors

### DIFF
--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -61,7 +61,7 @@ defmodule Redix.PubSub.Connection do
       {:error, reason} ->
         log state, :failed_connection, [
           "Failed to connect to Redis (", Utils.format_host(state), "): ",
-          ConnectionError.format_reason(reason)
+          Exception.message(%ConnectionError{reason: reason})
         ]
 
         next_backoff = calc_next_backoff(state.backoff_current || state.opts[:backoff_initial], state.opts[:backoff_max])


### PR DESCRIPTION
I'm afraid that my previous PR https://github.com/whatyouhide/redix_pubsub/pull/10 introduced an issue with the handling of connection errors from `Redix.Utils.connect/1`.

It looks like the underlying call to `:gen_tcp.connect/4` will return low level error atoms, which `Redix` will not wrap with the new error structs. The updated `case` pattern will fail to match on the atom, and an exception will be raised that will crash the application.

Example error stack trace:

```
22:38:19.432 [error] GenServer :fun_with_flags_notifications terminating
** (CaseClauseError) no case clause matching: {:error, :econnrefused}
    (redix_pubsub) lib/redix/pubsub/connection.ex:47: Redix.PubSub.Connection.connect/2
    (connection) lib/connection.ex:741: Connection.connect/3
    (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: {:timeout, #Reference<0.0.1.691>, Connection}
State: %Redix.PubSub.Connection{backoff_current: 500, continuation: nil, opts: [socket_opts: [], backoff_initial: 500, backoff_max: 30000, log: [disconnection: :error, failed_connection: :error, reconnection: :info], exit_on_disconnection: false, sync_connect: false, host: "localhost", port: 6379, database: 0], socket: nil, subscriptions: %{{:channel, "fun_with_flags_changes"} => %{#PID<0.213.0> => #Reference<0.0.8.10>}}}
```

This PR adds an explicit error handler to `Redix.PubSub.Connection.connect/2`, that will correctly accept error structs and atoms.
Tested with Redix 0.6.0 and 0.6.1