### PR TITLE
It should not be a fatal error if the connection receives a message …

### DIFF
--- a/lib/redix/pubsub/connection.ex
+++ b/lib/redix/pubsub/connection.ex
@@ -280,7 +280,7 @@ defmodule Redix.PubSub.Connection do
     message = message(:message, %{channel: channel, payload: payload})
 
     subscriptions
-    |> Map.fetch!({:channel, channel})
+    |> Map.get({:channel, channel}, [])
     |> Enum.each(fn({subscriber, _monitor}) -> send(subscriber, message) end)
 
     state
@@ -290,7 +290,7 @@ defmodule Redix.PubSub.Connection do
     message = message(:pmessage, %{channel: channel, pattern: pattern, payload: payload})
 
     subscriptions
-    |> Map.fetch!({:pattern, pattern})
+    |> Map.get({:pattern, pattern}, [])
     |> Enum.each(fn({subscriber, _monitor}) -> send(subscriber, message) end)
 
     state
@@ -378,7 +378,7 @@ defmodule Redix.PubSub.Connection do
       |> Keyword.fetch!(action)
     Logger.log(level, message)
   end
-  
+
   # TODO: remove once we depend on Elixir 1.4 and on.
   Code.ensure_loaded(Enum)
 


### PR DESCRIPTION
… for a channel to which it is not subscribed.

Observed the following race condition (unfortunately, I haven't generated a successful test to generate this condition):

1. Publish a message to a channel.
2. Subscribe to that channel. (The race is that steps 1 and 2 may overlap in unpredictable fashion.)
3. Receive the message from [1] before subscription confirmation (I think).
4. Crash at line 283 because there's no matching `{:channel, channel}` key.